### PR TITLE
fix general rule for buttons

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 # Unrounded Corners
 A Nextcloud app that restores the corners of buttons and widgets to their original looks by unrounding them.
     ]]></description>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <licence>agpl</licence>
     <author mail="me@oliverparoczai.org" homepage="https://oliverparoczai.dev">Oliver Paroczai</author>
     <namespace>UnroundedCorners</namespace>

--- a/css/unround.css
+++ b/css/unround.css
@@ -22,3 +22,14 @@
 #uploadprogressbar { /* For upload progress bar */
     border-radius: var(--border-radius-pill) 0 0 var(--border-radius-pill) !important;
 }
+
+/* For buttons */
+input[type='submit'],
+input[type='submit'].icon-confirm,
+input[type='button'],
+button,
+a.button,
+.button,
+select {
+    border-radius: var(--border-radius-pill) !important;
+}


### PR DESCRIPTION
fix #2 

before:
<img width="316" alt="image" src="https://user-images.githubusercontent.com/9200155/137543769-a2c244bb-ad69-4d82-ad0e-a9623d4b1ef4.png">

after:
<img width="335" alt="image" src="https://user-images.githubusercontent.com/9200155/137543740-6f65ffab-1af6-4727-9a1d-f46faa4ec5a6.png">

I think that we could align the login button as well, but I don't know if it makes sense for this app. What do you think?
