### PR TITLE
Version v1.1.1 (Apply styles uniformly to guest pages)

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 # Unrounded Corners
 A Nextcloud app that restores the corners of buttons and widgets to their original looks by unrounding them.
     ]]></description>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <licence>agpl</licence>
     <author mail="me@oliverparoczai.org" homepage="https://oliverparoczai.dev">Oliver Paroczai</author>
     <namespace>UnroundedCorners</namespace>

--- a/css/unround.css
+++ b/css/unround.css
@@ -1,8 +1,9 @@
-:root { /* Body container settings, mostly for removing the side margins */
+:root { /* Body container settings, mostly for removing the side margins, and for applying the styles to guest pages */
 --body-container-margin: 0px !important;
 --body-container-radius: 0px !important;
---border-radius-large: 0px !important;
---border-radius-rounded: 0px !important; 
+--border-radius-large: 4px !important;
+--border-radius-rounded: 4px !important; 
+--border-radius-pill: 4px !important;
 }
 
 [data-theme-default], [data-theme-light], [data-theme-dark], [data-theme-light-highcontrast], [data-theme-dark-highcontrast]{ /* For sitewide buttons, both themes */


### PR DESCRIPTION
- Guest pages now use the same border radii in all cases as the logged-in (themed) pages
  - This also fixes the new login screen info bar introduced in NC 27